### PR TITLE
Add Runic Healing Injector to WotLK list

### DIFF
--- a/Core/Potions.lua
+++ b/Core/Potions.lua
@@ -24,6 +24,7 @@ ham.aged = ham.Item.new(136569, "Aged Health Potion")
 ham.tonic = ham.Item.new(109223, "Healing Tonic")
 ham.master = ham.Item.new(76097, "Master Healing Potion")
 ham.mythical = ham.Item.new(57191, "Mythical Healing Potion")
+ham.runic_inject = ham.Item.new(41166, "Runic Healing Injector")
 ham.runic = ham.Item.new(33447, "Runic Healing Potion")
 ham.superreju = ham.Item.new(22850, "Super Rejuvenation Potion")
 ham.endless = ham.Item.new(43569, "Endless Healing Potion")
@@ -117,6 +118,7 @@ function ham.getPots()
 
   if isWrath then
     return {
+      ham.runic_inject,
       ham.runic,
       ham.superreju,
       ham.endless,


### PR DESCRIPTION
Add Runic Healing Injector to the lists so engineers can use their updated potions.