### PR TITLE
fix uses of C_Spell.GetSpellCooldown

### DIFF
--- a/Core/Spells.lua
+++ b/Core/Spells.lua
@@ -49,7 +49,7 @@ ham.Spell.new = function(id, name)
 
     self.id = id
     self.name = name
-    self.cd = C_Spell.GetSpellCooldown(id)
+    self.cd = C_Spell.GetSpellCooldown(id).duration
 
     function self.getId()
         return self.id

--- a/code.lua
+++ b/code.lua
@@ -74,8 +74,7 @@ local function buildSpellMacroString()
       local name = C_Spell.GetSpellName(spell)
 
       if HAMDB.cdReset then
-        local cooldownMS, gcdMS = C_Spell.GetSpellCooldown(spell)
-        local cd = cooldownMS / 1000
+        local cd = C_Spell.GetSpellCooldown(spell).duration
         if shortestCD == nil then
           shortestCD = cd
         end


### PR DESCRIPTION
With 11.0.2, GetSpellCooldown changed to C_Spell.GetSpellCooldown which has a slightly different signature: https://warcraft.wiki.gg/wiki/API_C_Spell.GetSpellCooldown

It now returns a single object (or nil) whose `duration` property is the cd in seconds.