### PR TITLE
Healthstone changes

### DIFF
--- a/Core/DB.lua
+++ b/Core/DB.lua
@@ -4,6 +4,7 @@ ham.defaults = {
     raidStone = false,
     witheringPotion = false,
     witheringDreamsPotion = false,
+    useHealthstones = true,
     activatedSpells = { ham.crimsonVialSpell, ham.renewal, ham.exhilaration, ham.fortitudeOfTheBear, ham.bitterImmunity,
         ham.desperatePrayer, ham.healingElixir, ham.giftOfTheNaaruDK, ham.giftOfTheNaaruHunter, ham.giftOfTheNaaruMage,
         ham.giftOfTheNaaruMageWarlock, ham.giftOfTheNaaruMonk, ham.giftOfTheNaaruPaladin, ham.giftOfTheNaaruPriest, ham

--- a/Core/Player.lua
+++ b/Core/Player.lua
@@ -9,9 +9,6 @@ ham.Player.new = function()
 
   function self.getHealingItems()
     local healingItems = {}
-    ham.demonicHealthstoneItem = ham.Item.new(224464, "Demonic Healthstone")
-
-    table.insert(healingItems, ham.demonicHealthstoneItem)
 
     return healingItems
   end

--- a/FrameXML/InterfaceOptionsFrame.lua
+++ b/FrameXML/InterfaceOptionsFrame.lua
@@ -274,6 +274,19 @@ function ham.settingsFrame:InitializeOptions()
 		lastStaticElement = witheringPotionButton ---MAYBE witheringDreamsPotionButton
 	end
 
+	local useHealthstonesButton = CreateFrame("CheckButton", nil, self.panel, "InterfaceOptionsCheckButtonTemplate")
+	useHealthstonesButton:SetPoint("TOPLEFT", lastStaticElement, 0, -PADDING)
+	---@diagnostic disable-next-line: undefined-field
+	useHealthstonesButton.Text:SetText("Include Healthstones")
+	useHealthstonesButton:HookScript("OnClick", function(_, btn, down)
+		HAMDB.useHealthstones = useHealthstonesButton:GetChecked()
+		ham.updateHeals()
+		ham.updateMacro()
+		self:updatePrio()
+	end)
+	useHealthstonesButton:SetChecked(HAMDB.useHealthstones)
+	lastStaticElement = useHealthstonesButton
+
 
 	-------------  CURRENT PRIORITY  -------------
 	currentPrioTitle = self.panel:CreateFontString("ARTWORK", nil, "GameFontNormalHuge")
@@ -302,6 +315,7 @@ function ham.settingsFrame:InitializeOptions()
 			witheringPotionButton:SetChecked(HAMDB.witheringPotion)
 			witheringDreamsPotionButton:SetChecked(HAMDB.witheringDreamsPotion)
 		end
+		useHealthstonesButton:SetChecked(HAMDB.useHealthstones)
 		ham.updateHeals()
 		ham.updateMacro()
 		self:updatePrio()

--- a/code.lua
+++ b/code.lua
@@ -25,6 +25,9 @@ local function addPlayerHealingItemIfAvailable()
 end
 
 local function addHealthstoneIfAvailable()
+  if not HAMDB.useHealthstones then
+    return
+  end
   if isClassic == true or isWrath == true then
     for i, value in ipairs(ham.getHealthstonesClassic()) do
       if value.getCount() > 0 then


### PR DESCRIPTION
This stops DemonicHealthstone being duplicated in the macro, and also adds an option to disable including health stones entirely.