### PR TITLE
MegaMacro Compatiblity & Other Enhancements

### DIFF
--- a/Core/Potions.lua
+++ b/Core/Potions.lua
@@ -96,6 +96,17 @@ function RemoveFromList(list, itemToRemove)
   end
 end
 
+function ham.getDelightPots()
+  if isRetail then
+    return {
+      ham.cavedwellersDelightR3,
+      ham.cavedwellersDelightR2,
+      ham.cavedwellersDelightR1,
+    }
+  end
+  return {}
+end
+
 function ham.getPots()
   if isRetail then
     local pots = {
@@ -105,9 +116,6 @@ function ham.getPots()
       ham.fleetingAlgariHealingPotionR3,
       ham.fleetingAlgariHealingPotionR2,
       ham.fleetingAlgariHealingPotionR1,
-      ham.cavedwellersDelightR3,
-      ham.cavedwellersDelightR2,
-      ham.cavedwellersDelightR1,
       ham.thirdWind,
       ham.witheringDreamsR3,
       ham.witheringDreamsR2,
@@ -160,12 +168,6 @@ function ham.getPots()
       RemoveFromList(pots, ham.witheringDreamsR1)
       RemoveFromList(pots, ham.witheringDreamsR2)
       RemoveFromList(pots, ham.witheringDreamsR3)
-    end
-
-    if not HAMDB.cavedwellerDelight then
-      RemoveFromList(pots, ham.cavedwellersDelightR1)
-      RemoveFromList(pots, ham.cavedwellersDelightR2)
-      RemoveFromList(pots, ham.cavedwellersDelightR3)
     end
 
     return pots

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-Auto Potion was previously known as Healthstone Auto Macro.
-This Addon will maintain a Macro for you which uses several self healing Spells, Healthstone and Healing Potions in you Bag.
+# Auto Potion
+
+Auto Potion was previously known as Healthstone Auto Macro. This Addon will maintain a Macro for you which uses several self healing Spells, Healthstone and Healing Potions in you Bag.
+
 The Priority is: Player Healing Spells like (Renewal) -> Crimson Vial (disabled by default) -> Healthstone -> Highest Healing Potion in Bag
 But it will prefer Healthstone over all Healing Potions.
 
@@ -8,14 +10,18 @@ You can also directly Keybind the Addon you find it in the Keybind Settings but 
 Which Player Healing Spells are used is configured in the Addon Settings (/ap).
 I will maintain a best practise as Default but you can change the behaviour if you really want to.
 
-How it works:
+## How it works:
 
 It's actually a very basic addon which will update the given macro every time you either login or your Bag is updated. Therefore it will keep up to date if you just pick up Healthstones.
 
-How to use:
+## How to use:
 
 1. Install Addon
 2. Create a empty Macro called "AutoPotion"
 3. Move Macro to Button or Keybind it
 4. reload
 5. Profit!
+
+## MegaMacro Compatibility
+
+To use this addon alongside MegaMacro, you must first manually create a **Global** macro in MegaMacro, named `AutoPotion`, then `/reload` your game.

--- a/code.lua
+++ b/code.lua
@@ -4,8 +4,6 @@ local isRetail = (WOW_PROJECT_ID == WOW_PROJECT_MAINLINE)
 local isClassic = (WOW_PROJECT_ID == WOW_PROJECT_CLASSIC)
 local isWrath = (WOW_PROJECT_ID == WOW_PROJECT_WRATH_CLASSIC)
 local isCata = (WOW_PROJECT_ID == WOW_PROJECT_CATACLYSM_CLASSIC)
-local isRetail = (WOW_PROJECT_ID == WOW_PROJECT_MAINLINE)
-
 
 ham.myPlayer = ham.Player.new()
 

--- a/code.lua
+++ b/code.lua
@@ -67,9 +67,11 @@ local function addHealthstoneIfAvailable()
   end
 end
 
-local function addPotIfAvailable()
+local function addPotIfAvailable(useDelightPots)
   log("Updating pot counts...")
-  for i, value in ipairs(ham.getPots()) do
+  useDelightPots = useDelightPots or false
+  local pots = useDelightPots and ham.getDelightPots() or ham.getPots()
+  for i, value in ipairs(pots) do
     log("Item: " .. tostring(value.getId()) .. " Count: " .. tostring(value.getCount()))
     if value.getCount() > 0 then
       table.insert(ham.itemIdList, value.getId())
@@ -88,10 +90,16 @@ function ham.updateHeals()
   -- lower the priority of healthstones in insatanced content if selected
   if HAMDB.raidStone and IsInInstance() then
     addPotIfAvailable()
+    if HAMDB.cavedwellerDelight then
+      addPotIfAvailable(true)
+    end
     addHealthstoneIfAvailable()
   else
     addHealthstoneIfAvailable()
     addPotIfAvailable()
+    if HAMDB.cavedwellerDelight then
+      addPotIfAvailable(true)
+    end
   end
 end
 


### PR DESCRIPTION
This PR aims to provide compatibility with the MegaMacro addon, and resolve issue https://github.com/ollidiemaus/AutoPotion/issues/40 .
For an explanation of the compatibility issue, see my [comment here](https://github.com/ollidiemaus/AutoPotion/issues/40#issuecomment-2395657149).

The changes I've made include:
- Removed a duplicated `isRetail` definition.
- Updated the event handler, to provide more reliable combat checking, through `UnitAffectingCombat()`
- Removed the `PLAYER_REGEN_DISABLED` event registration -- there is no practical use of tracking when a player enters combat, since macros cannot be created or updated while in combat.
- Debounced the `BAG_UPDATE` event, which can fire **rapidly** depending on player actions, and if they have bag addons installed. Most bag addons will typically cause **ALOT** of BAG_UPDATE events to fire, especially on login.
- Adds compatibility with MegaMacro:
    - Implements a check to see if a player has MegaMacro installed and loaded.
    - Checks MegaMacro's internal table for the existence of the `AutoPotion` macro.
    - Hooks into MegaMacro's `UpdateCode()` method to update the AutoPotion macro.

If a player is using MegaMacro, this update requires that a player first create an empty macro named `AutoPotion`, and then reload their game. It should work as expected from there. I have updated the readme to reflect this. I could probably hook into MegaMacro's create method as well, but I opted to keep this compatibility change as simple as possible, in the event MegaMacro releases breaking changes.