### PR TITLE
fix: fortitude of the bear

### DIFF
--- a/Core/Player.lua
+++ b/Core/Player.lua
@@ -16,7 +16,7 @@ ham.Player.new = function()
     local spells = {}
 
     for i, spell in ipairs(HAMDB.activatedSpells) do
-      if IsSpellKnown(spell) then
+      if IsSpellKnown(spell) or IsSpellKnown(spell, true) then
         table.insert(spells, spell)
       end
     end

--- a/Core/Spells.lua
+++ b/Core/Spells.lua
@@ -5,7 +5,7 @@ local isRetail = (WOW_PROJECT_ID == WOW_PROJECT_MAINLINE)
 ham.crimsonVialSpell = 185311
 ham.renewal = 108238
 ham.exhilaration = 109304
-ham.fortitudeOfTheBear = 272679
+ham.fortitudeOfTheBear = 388035
 ham.bitterImmunity = 383762
 ham.desperatePrayer = 19236
 ham.expelHarm = 322101

--- a/FrameXML/InterfaceOptionsFrame.lua
+++ b/FrameXML/InterfaceOptionsFrame.lua
@@ -360,7 +360,7 @@ function ham.settingsFrame:InitializeClassSpells(relativeTo)
 	if next(ham.supportedSpells) ~= nil then
 		local count = 0
 		for i, spell in ipairs(ham.supportedSpells) do
-			if IsSpellKnown(spell) then
+			if IsSpellKnown(spell) or IsSpellKnown(spell, true) then
 				local name = C_Spell.GetSpellName(spell)
 				local button = CreateFrame("CheckButton", nil, self.content, "InterfaceOptionsCheckButtonTemplate")
 

--- a/code.lua
+++ b/code.lua
@@ -309,20 +309,6 @@ local function onBagUpdate()
   end)
 end
 
-local petUpdates = false
-
-local function petUpdate()
-  if petUpdates then
-    return
-  end
-  log("event: UNIT_PET")
-  petUpdates = true
-  C_Timer.After(debounceTime, function()
-    MakeMacro()
-    petUpdates = false
-  end)
-end
-
 local updateFrame = CreateFrame("Frame")
 updateFrame:RegisterEvent("ADDON_LOADED")
 updateFrame:RegisterEvent("BAG_UPDATE")

--- a/code.lua
+++ b/code.lua
@@ -309,6 +309,20 @@ local function onBagUpdate()
   end)
 end
 
+local petUpdates = false
+
+local function petUpdate()
+  if petUpdates then
+    return
+  end
+  log("event: UNIT_PET")
+  petUpdates = true
+  C_Timer.After(debounceTime, function()
+    MakeMacro()
+    petUpdates = false
+  end)
+end
+
 local updateFrame = CreateFrame("Frame")
 updateFrame:RegisterEvent("ADDON_LOADED")
 updateFrame:RegisterEvent("BAG_UPDATE")
@@ -317,6 +331,7 @@ if isClassic == false then
   updateFrame:RegisterEvent("TRAIT_CONFIG_UPDATED")
 end
 updateFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
+updateFrame:RegisterEvent("UNIT_PET")
 updateFrame:SetScript("OnEvent", function(self, event, arg1, ...)
   -- when addon is loaded
   if event == "ADDON_LOADED" and arg1 == addonName then
@@ -332,6 +347,9 @@ updateFrame:SetScript("OnEvent", function(self, event, arg1, ...)
   -- bag update events
   if event == "BAG_UPDATE" then
     onBagUpdate()
+  elseif event == "UNIT_PET" then
+    log("event: UNIT_PET")
+    MakeMacro()
   -- on loading/reloading
   elseif event == "PLAYER_ENTERING_WORLD" then
     log("event: PLAYER_ENTERING_WORLD")


### PR DESCRIPTION
# Summary

This PR:
- changes the spellid for fortitude of the bear to be[ one that](https://www.wowhead.com/spell=388035/fortitude-of-the-bear) works with the IsSpellKnown pet modifier
- Updates the population of the spells in the interface to 'or' with the pet modifier from the api
- adds a UNIT_PET event registration for updates on pet summon and dismissal

The main issue is that fortitude of the bear wasn't working properly in retail - the previous spell id wasn't showing up in the options at all. 