### PR TITLE
Fix: Invigorating Healing Potion

### DIFF
--- a/Core/Potions.lua
+++ b/Core/Potions.lua
@@ -126,6 +126,9 @@ end
 function ham.getPots()
   if isRetail then
     local pots = {
+      ham.invigoratingHealingPotionR3,
+      ham.invigoratingHealingPotionR2,
+      ham.invigoratingHealingPotionR1,
       ham.fleetingAlgariHealingPotionR3,
       ham.algariHealingPotionR3,
       ham.fleetingAlgariHealingPotionR2,


### PR DESCRIPTION
The invigorating healing potions were present in the base array but missing from the "isRetail" array. This adds them to the correct array so they show up under the "Current Priority" section and are usable.