### PR TITLE
refactor: stabilize init, UI, and macro flow; schema-driven options; …

### DIFF
--- a/AutoPotion.toc
+++ b/AutoPotion.toc
@@ -28,6 +28,7 @@ embeds.xml
 Locales\Locales.xml
 
 Core/Constants.lua
+Core/Macro.lua
 Core/Spells.lua
 Core/Item.lua
 Core/DB.lua

--- a/Core/Constants.lua
+++ b/Core/Constants.lua
@@ -7,3 +7,108 @@ ham.MAP_ID_WARSONG_GULCH = 1460
 ham.MAP_ID_ARATHI_BASIN = 1461
 
 
+-- Environment flags centralized for reuse across modules
+ham.env = {
+  isRetail = (WOW_PROJECT_ID == WOW_PROJECT_MAINLINE),
+  isClassic = (WOW_PROJECT_ID == WOW_PROJECT_CLASSIC),
+  isWrath = (WOW_PROJECT_ID == WOW_PROJECT_WRATH_CLASSIC),
+  isCata = (WOW_PROJECT_ID == WOW_PROJECT_CATACLYSM_CLASSIC),
+  isMop = (WOW_PROJECT_ID == WOW_PROJECT_MISTS_CLASSIC),
+}
+
+-- Shared string constants
+ham.SLOT_PREFIX = "slot:"
+-- Slot IDs
+ham.SLOT_HEAD = 1
+ham.SLOT_WRIST = 9
+ham.SLOT_RANGED = 18
+ham.SLOT_TRINKET2 = 14
+
+-- Common helpers
+function ham.getEnvKey()
+  local env = ham.env
+  if env and env.isRetail then return "retail" end
+  if env and env.isClassic then return "classic" end
+  if env and env.isWrath then return "wrath" end
+  if env and env.isCata then return "cata" end
+  if env and env.isMop then return "mop" end
+  return "unknown"
+end
+
+function ham.copyList(list)
+  local out = {}
+  for i, v in ipairs(list or {}) do out[i] = v end
+  return out
+end
+
+-- Simple deferral helper
+function ham.defer(seconds, fn)
+  C_Timer.After(seconds, fn)
+end
+
+-- Event names
+ham.EVT_ADDON_LOADED = "ADDON_LOADED"
+ham.EVT_BAG_UPDATE = "BAG_UPDATE"
+ham.EVT_PLAYER_ENTERING_WORLD = "PLAYER_ENTERING_WORLD"
+ham.EVT_PLAYER_EQUIPMENT_CHANGED = "PLAYER_EQUIPMENT_CHANGED"
+ham.EVT_TRAIT_CONFIG_UPDATED = "TRAIT_CONFIG_UPDATED"
+ham.EVT_PLAYER_REGEN_ENABLED = "PLAYER_REGEN_ENABLED"
+ham.EVT_UNIT_PET = "UNIT_PET"
+ham.EVT_PLAYER_LOGIN = "PLAYER_LOGIN"
+
+-- UI helpers namespace
+ham.ui = ham.ui or {}
+
+function ham.ui.attachSpellTooltip(frame, spellId)
+  frame:HookScript("OnEnter", function()
+    GameTooltip:SetOwner(frame, "ANCHOR_TOPRIGHT")
+    GameTooltip:SetSpellByID(spellId)
+    GameTooltip:Show()
+  end)
+  frame:HookScript("OnLeave", function()
+    GameTooltip:Hide()
+  end)
+end
+
+function ham.ui.attachItemTooltip(frame, itemId)
+  frame:HookScript("OnEnter", function()
+    GameTooltip:SetOwner(frame, "ANCHOR_TOPRIGHT")
+    GameTooltip:SetItemByID(itemId)
+    GameTooltip:Show()
+  end)
+  frame:HookScript("OnLeave", function()
+    GameTooltip:Hide()
+  end)
+end
+
+function ham.ui.attachInventoryTooltip(frame, slotId)
+  frame:HookScript("OnEnter", function()
+    GameTooltip:SetOwner(frame, "ANCHOR_TOPRIGHT")
+    GameTooltip:SetInventoryItem("player", slotId)
+    GameTooltip:Show()
+  end)
+  frame:HookScript("OnLeave", function()
+    GameTooltip:Hide()
+  end)
+end
+
+-- Item/macro entry formatter for slot or item id
+function ham.formatItemEntry(idOrSlot)
+  if type(idOrSlot) == "string" and idOrSlot:match("^" .. ham.SLOT_PREFIX) then
+    return idOrSlot:sub(#ham.SLOT_PREFIX + 1)
+  end
+  return "item:" .. tostring(idOrSlot)
+end
+
+-- Item icon helper (works across clients, with fallbacks)
+function ham.getItemIcon(itemId)
+  if C_Item and C_Item.GetItemIconByID then
+    return C_Item.GetItemIconByID(itemId)
+  end
+  if GetItemIcon then
+    return GetItemIcon(itemId)
+  end
+  return nil
+end
+
+

--- a/Core/DB.lua
+++ b/Core/DB.lua
@@ -17,28 +17,28 @@ ham.defaults = {
 
 
 function ham.dbContains(id)
-    local found = false
-    for _, v in pairs(HAMDB.activatedSpells) do
+    if not HAMDB or not HAMDB.activatedSpells then return false end
+    for _, v in ipairs(HAMDB.activatedSpells) do
         if v == id then
-            found = true
+            return true
         end
     end
-    return found
+    return false
 end
 
 function ham.removeFromDB(id)
-    local backup = {}
-    if ham.dbContains(id) then
-        for _, v in pairs(HAMDB.activatedSpells) do
-            if v ~= id then
-                table.insert(backup, v)
-            end
+    if not HAMDB or not HAMDB.activatedSpells then return end
+    for i = #HAMDB.activatedSpells, 1, -1 do
+        if HAMDB.activatedSpells[i] == id then
+            table.remove(HAMDB.activatedSpells, i)
         end
     end
-
-    HAMDB.activatedSpells = CopyTable(backup)
 end
 
 function ham.insertIntoDB(id)
-    table.insert(HAMDB.activatedSpells, id)
+    if not HAMDB then return end
+    HAMDB.activatedSpells = HAMDB.activatedSpells or {}
+    if not ham.dbContains(id) then
+        table.insert(HAMDB.activatedSpells, id)
+    end
 end

--- a/Core/Item.lua
+++ b/Core/Item.lua
@@ -8,12 +8,7 @@ ham.Item.new = function(id, name)
   self.id = id
   self.name = name
 
-  local function setName()
-    local itemInfoName = C_Item.GetItemInfo(self.id)
-    if itemInfoName ~= nil then
-      self.name = itemInfoName
-    end
-  end
+  local function setName() end
 
   function self.getId()
     return self.id

--- a/Core/Macro.lua
+++ b/Core/Macro.lua
@@ -1,0 +1,88 @@
+local addonName, ham = ...
+local env = ham.env
+
+ham.macro = ham.macro or {}
+
+local state = {
+  name = "MegaMacro",
+  retries = 0,
+  checked = false,
+  installed = false,
+  loaded = false,
+}
+
+ham.macro.state = state
+ham.macro.retryDelay = 3
+
+function ham.macro.checkAddonReady()
+  -- MegaMacro only exists on retail; consider non-retail as "checked"
+  if not (env and env.isRetail) then
+    state.checked = true
+    return true
+  end
+
+  local addonNameInfo = C_AddOns.GetAddOnInfo(state.name)
+  if not addonNameInfo then
+    state.installed = false
+    state.checked = true
+    return true
+  end
+
+  state.installed = true
+
+  if C_AddOns.IsAddOnLoaded(state.name) then
+    state.loaded = true
+    state.checked = true
+    return true
+  end
+
+  if state.retries < 3 then
+    state.retries = state.retries + 1
+    ham.defer(ham.macro.retryDelay, ham.macro.checkAddonReady)
+  else
+    state.checked = true
+  end
+  return state.checked
+end
+
+local function ensureMacroExists(name)
+  -- Don't try to create if MegaMacro is available; handled there
+  local existing = GetMacroInfo(name)
+  if not existing then
+    pcall(function()
+      CreateMacro(name, "INV_Misc_QuestionMark")
+    end)
+  end
+end
+
+local function applyViaMegaMacro(name, code)
+  if not _G.MegaMacroGlobalData or not _G.MegaMacro then return false end
+  for _, macro in pairs(MegaMacroGlobalData.Macros) do
+    if macro.DisplayName == name then
+      MegaMacro.UpdateCode(macro, code)
+      return true
+    end
+  end
+  print("|cffff0000AutoPotion Error:|r Missing global '" .. tostring(name) .. "' macro in MegaMacro. Please create it then reload your game.")
+  return false
+end
+
+function ham.macro.apply(name, code)
+  ham.macro.checkAddonReady()
+
+  -- If MegaMacro is loaded and available, prefer it
+  if state.installed and state.loaded then
+    local ok = applyViaMegaMacro(name, code)
+    if ok then return true end
+    -- fall through to default macro if MegaMacro missing a global macro
+  end
+
+  -- Default in-game macro path
+  ensureMacroExists(name)
+  local success = pcall(function()
+    EditMacro(name, name, nil, code)
+  end)
+  return success and true or false
+end
+
+

--- a/Core/Player.lua
+++ b/Core/Player.lua
@@ -7,15 +7,12 @@ ham.Player.new = function()
 
   self.localizedClass, self.englishClass, self.classIndex = UnitClass("player");
 
-  function self.getHealingItems()
-    local healingItems = {}
-    return healingItems
-  end
-
   function self.getHealingSpells()
     local spells = {}
-
-    for i, spell in ipairs(HAMDB.activatedSpells) do
+    local activated = (type(HAMDB) == "table" and HAMDB.activatedSpells)
+        or (ham.defaults and ham.defaults.activatedSpells)
+        or {}
+    for i, spell in ipairs(activated) do
       if IsSpellKnown(spell) or IsSpellKnown(spell, true) then
         table.insert(spells, spell)
       end

--- a/Core/Potions.lua
+++ b/Core/Potions.lua
@@ -1,10 +1,6 @@
 ---@diagnostic disable: undefined-global
 local addonName, ham = ...
-local isRetail = (WOW_PROJECT_ID == WOW_PROJECT_MAINLINE)
-local isClassic = (WOW_PROJECT_ID == WOW_PROJECT_CLASSIC)
-local isWrath = (WOW_PROJECT_ID == WOW_PROJECT_WRATH_CLASSIC)
-local isCata = (WOW_PROJECT_ID == WOW_PROJECT_CATACLYSM_CLASSIC)
-local isMop = (WOW_PROJECT_ID == WOW_PROJECT_MISTS_CLASSIC)
+local env = ham.env
 
 ham.healthstone = ham.Item.new(5512, "Healthstone")
 ham.demonicHealthstone = ham.Item.new(224464, "Demonic Healthstone") ---1 Minute CD due to Pact of Gluttony
@@ -108,6 +104,130 @@ ham.fel1 = ham.Item.new(36893, "Fel Healthstone")
 ham.fel2 = ham.Item.new(36894, "Fel Healthstone")
 ------Healthstones for Cata------
 
+-- Determine environment key
+local getEnvKey = ham.getEnvKey
+local copyList = ham.copyList
+
+-- Consolidated potion lists per environment
+local POTIONS_BY_ENV = {
+  retail = {
+    ham.fleetingInvigoratingHealingPotionR3,
+    ham.invigoratingHealingPotionR3,
+    ham.fleetingInvigoratingHealingPotionR2,
+    ham.invigoratingHealingPotionR2,
+    ham.fleetingInvigoratingHealingPotionR1,
+    ham.invigoratingHealingPotionR1,
+    ham.fleetingAlgariHealingPotionR3,
+    ham.algariHealingPotionR3,
+    ham.fleetingAlgariHealingPotionR2,
+    ham.algariHealingPotionR2,
+    ham.fleetingAlgariHealingPotionR1,
+    ham.algariHealingPotionR1,
+    ham.thirdWind,
+    ham.survivalistsHealingPotion,
+    ham.witheringDreamsR3,
+    ham.witheringDreamsR2,
+    ham.witheringDreamsR1,
+    ham.dreamR3,
+    ham.dreamsR2,
+    ham.dreamR1,
+    ham.witheringR3,
+    ham.witheringR2,
+    ham.witheringR1,
+    ham.refreshingR3,
+    ham.refreshingR2,
+    ham.refreshingR1,
+    ham.cosmic,
+    ham.spiritual,
+    ham.soulful,
+    ham.ashran,
+    ham.abyssal,
+    ham.astral,
+    ham.coastal,
+    ham.ancient,
+    ham.aged,
+    ham.tonic,
+    ham.master,
+    ham.mythical,
+    ham.runic,
+    ham.resurgent,
+    ham.super,
+    ham.major,
+    ham.lesser,
+    ham.superior,
+    ham.minor,
+    ham.greater,
+    ham.healingPotion
+  },
+  classic = {
+    ham.major,
+    ham.combat,
+    ham.superior,
+    ham.greater,
+    ham.healingPotion,
+    ham.lesser,
+    ham.minor
+  },
+  wrath = {
+    ham.crazy_alch,
+    ham.runic_inject,
+    ham.runic,
+    ham.superreju,
+    ham.endless,
+    ham.injector,
+    ham.resurgent,
+    ham.super,
+    ham.argent,
+    ham.auchenai,
+    ham.major,
+    ham.superior,
+    ham.greater,
+    ham.healingPotion,
+    ham.lesser,
+    ham.minor
+  },
+  cata = {
+    ham.roguesDraught,
+    ham.mythical,
+    ham.crazy_alch,
+    ham.runic_inject,
+    ham.runic,
+    ham.superreju,
+    ham.endless,
+    ham.injector,
+    ham.resurgent,
+    ham.super,
+    ham.argent,
+    ham.auchenai,
+    ham.major,
+    ham.superior,
+    ham.greater,
+    ham.healingPotion,
+    ham.lesser,
+    ham.minor
+  },
+  mop = {
+    ham.master,
+    ham.roguesDraught,
+    ham.mythical,
+    ham.crazy_alch,
+    ham.runic_inject,
+    ham.runic,
+    ham.superreju,
+    ham.endless,
+    ham.injector,
+    ham.resurgent,
+    ham.super,
+    ham.argent,
+    ham.auchenai,
+    ham.major,
+    ham.superior,
+    ham.greater,
+    ham.healingPotion,
+    ham.lesser,
+    ham.minor
+  }
+}
 function RemoveFromList(list, itemToRemove)
   for i = #list, 1, -1 do
     if list[i] == itemToRemove then
@@ -117,294 +237,96 @@ function RemoveFromList(list, itemToRemove)
 end
 
 function ham.getDelightPots()
-  if isRetail then
-    return {
-      ham.cavedwellersDelightR3,
-      ham.cavedwellersDelightR2,
-      ham.cavedwellersDelightR1,
-      ham.fleetingCavedwellersDelightR3,
-      ham.fleetingCavedwellersDelightR2,
-      ham.fleetingCavedwellersDelightR1,
-    }
-  end
-  return {}
+  if getEnvKey() ~= "retail" then return {} end
+  return {
+    ham.cavedwellersDelightR3,
+    ham.cavedwellersDelightR2,
+    ham.cavedwellersDelightR1,
+    ham.fleetingCavedwellersDelightR3,
+    ham.fleetingCavedwellersDelightR2,
+    ham.fleetingCavedwellersDelightR1,
+  }
 end
 
 function ham.getPots()
-  if isRetail then
-    local pots = {
-      ham.fleetingInvigoratingHealingPotionR3,
-      ham.invigoratingHealingPotionR3,
-      ham.fleetingInvigoratingHealingPotionR2,
-      ham.invigoratingHealingPotionR2,
-      ham.fleetingInvigoratingHealingPotionR1,
-      ham.invigoratingHealingPotionR1,
-      ham.fleetingAlgariHealingPotionR3,
-      ham.algariHealingPotionR3,
-      ham.fleetingAlgariHealingPotionR2,
-      ham.algariHealingPotionR2,
-      ham.fleetingAlgariHealingPotionR1,
-      ham.algariHealingPotionR1,
-      ham.thirdWind,
-      ham.survivalistsHealingPotion,
-      ham.witheringDreamsR3,
-      ham.witheringDreamsR2,
-      ham.witheringDreamsR1,
-      ham.dreamR3,
-      ham.dreamsR2,
-      ham.dreamR1,
-      ham.witheringR3,
-      ham.witheringR2,
-      ham.witheringR1,
-      ham.refreshingR3,
-      ham.refreshingR2,
-      ham.refreshingR1,
-      ham.cosmic,
-      ham.spiritual,
-      ham.soulful,
-      ham.ashran,
-      ham.abyssal,
-      ham.astral,
-      ham.coastal,
-      ham.ancient,
-      ham.aged,
-      ham.tonic,
-      ham.master,
-      ham.mythical,
-      ham.runic,
-      ham.resurgent,
-      ham.super,
-      ham.major,
-      ham.lesser,
-      ham.superior,
-      ham.minor,
-      ham.greater,
-      ham.healingPotion
-    }
+  local key = getEnvKey()
+  local base = POTIONS_BY_ENV[key]
+  if not base then return {} end
+  local pots = copyList(base)
 
-
+  if key == "retail" then
     local isUnratedBattleground = C_PvP.IsBattleground() and not C_PvP.IsRatedBattleground()
-    if not isUnratedBattleground then
-      RemoveFromList(pots, ham.thirdWind)
-    end
+    if not isUnratedBattleground then RemoveFromList(pots, ham.thirdWind) end
 
-    if not HAMDB.witheringPotion then
+    if not ham.options.witheringPotion then
       RemoveFromList(pots, ham.witheringR1)
       RemoveFromList(pots, ham.witheringR2)
       RemoveFromList(pots, ham.witheringR3)
     end
-
-    if not HAMDB.witheringDreamsPotion then
+    if not ham.options.witheringDreamsPotion then
       RemoveFromList(pots, ham.witheringDreamsR1)
       RemoveFromList(pots, ham.witheringDreamsR2)
       RemoveFromList(pots, ham.witheringDreamsR3)
     end
-
-    return pots
-  end
-  if isClassic then
-    -- Base Classic potions list
-    local pots = {
-      ham.major,
-      ham.combat,
-      ham.superior,
-      ham.greater,
-      ham.healingPotion,
-      ham.lesser,
-      ham.minor
-    }
-
-    -- If in a PvP battleground, prioritize battleground draughts
+  elseif key == "classic" then
     local inInstance, instanceType = IsInInstance()
     local isInBattleground = inInstance and instanceType == "pvp"
     if isInBattleground then
-      -- Insert in reverse order so final priority is Major then Superior
       table.insert(pots, 1, ham.superiorHealingDraught)
       table.insert(pots, 1, ham.majorHealingDraught)
     end
-
-    return pots
   end
-
-  if isWrath then
-    return {
-      ham.crazy_alch,
-      ham.runic_inject,
-      ham.runic,
-      ham.superreju,
-      ham.endless,
-      ham.injector,
-      ham.resurgent,
-      ham.super,
-      ham.argent,
-      ham.auchenai,
-      ham.major,
-      ham.superior,
-      ham.greater,
-      ham.healingPotion,
-      ham.lesser,
-      ham.minor
-    }
-  end
-
-  if isCata then
-    return {
-      ham.roguesDraught,
-      ham.mythical,
-      ham.crazy_alch,
-      ham.runic_inject,
-      ham.runic,
-      ham.superreju,
-      ham.endless,
-      ham.injector,
-      ham.resurgent,
-      ham.super,
-      ham.argent,
-      ham.auchenai,
-      ham.major,
-      ham.superior,
-      ham.greater,
-      ham.healingPotion,
-      ham.lesser,
-      ham.minor
-    }
-  end
-
-  if isMop then
-    return {
-      ham.master,
-      ham.roguesDraught,
-      ham.mythical,
-      ham.crazy_alch,
-      ham.runic_inject,
-      ham.runic,
-      ham.superreju,
-      ham.endless,
-      ham.injector,
-      ham.resurgent,
-      ham.super,
-      ham.argent,
-      ham.auchenai,
-      ham.major,
-      ham.superior,
-      ham.greater,
-      ham.healingPotion,
-      ham.lesser,
-      ham.minor
-    }
-  end
+  return pots
 end
 
+-- Consolidated healthstone lists by environment
+local HEALTHSTONES_BY_ENV = {
+  classic = {
+    ham.major2, ham.major1, ham.major0,
+    ham.greater2, ham.greater1, ham.greater0,
+    ham.wipperRootTuber,
+    ham.healtsthone2, ham.healtsthone1,
+    ham.lilyRoot,
+    ham.healtsthone0,
+    ham.crystalFlakeThroatLozenge,
+    ham.lesser2, ham.lesser1, ham.lesser0,
+    ham.minor2, ham.minor1, ham.minor0,
+  },
+  wrath = {
+    ham.fel2, ham.fel1, ham.fel0,
+    ham.demonicWotLK2, ham.demonicWotLK1, ham.demonicWotLK0,
+    ham.master2, ham.master1, ham.master0,
+    ham.major2, ham.major1, ham.major0,
+    ham.greater2, ham.greater1, ham.greater0,
+    ham.healtsthone2, ham.healtsthone1, ham.healtsthone0,
+    ham.lesser2, ham.lesser1, ham.lesser0,
+    ham.minor2, ham.minor1, ham.minor0,
+  },
+  cata = {
+    ham.fel2, ham.fel1, ham.fel0,
+    ham.demonicWotLK2, ham.demonicWotLK1, ham.demonicWotLK0,
+    ham.master2, ham.master1, ham.master0,
+    ham.major2, ham.major1, ham.major0,
+    ham.greater2, ham.greater1, ham.greater0,
+    ham.healtsthone2, ham.healtsthone1, ham.healtsthone0,
+    ham.lesser2, ham.lesser1, ham.lesser0,
+    ham.minor2, ham.minor1, ham.minor0,
+  },
+  mop = {
+    ham.healthstone,
+    -- legacy
+    ham.fel2, ham.fel1, ham.fel0,
+    ham.demonicWotLK2, ham.demonicWotLK1, ham.demonicWotLK0,
+    ham.master2, ham.master1, ham.master0,
+    ham.major2, ham.major1, ham.major0,
+    ham.greater2, ham.greater1, ham.greater0,
+    ham.healtsthone2, ham.healtsthone1, ham.healtsthone0,
+    ham.lesser2, ham.lesser1, ham.lesser0,
+    ham.minor2, ham.minor1, ham.minor0,
+  },
+}
+
 function ham.getHealthstonesClassic()
-  if isClassic then
-    return {
-      ham.major2,
-      ham.major1,
-      ham.major0,
-      ham.greater2,
-      ham.greater1,
-      ham.greater0,
-      ham.wipperRootTuber,
-      ham.healtsthone2,
-      ham.healtsthone1,
-      ham.lilyRoot,
-      ham.healtsthone0,
-      ham.crystalFlakeThroatLozenge,
-      ham.lesser2,
-      ham.lesser1,
-      ham.lesser0,
-      ham.minor2,
-      ham.minor1,
-      ham.minor0
-    }
-  end
-
-  if isWrath then
-    return {
-      ham.fel2,
-      ham.fel1,
-      ham.fel0,
-      ham.demonicWotLK2,
-      ham.demonicWotLK1,
-      ham.demonicWotLK0,
-      ham.master2,
-      ham.master1,
-      ham.master0,
-      ham.major2,
-      ham.major1,
-      ham.major0,
-      ham.greater2,
-      ham.greater1,
-      ham.greater0,
-      ham.healtsthone2,
-      ham.healtsthone1,
-      ham.healtsthone0,
-      ham.lesser2,
-      ham.lesser1,
-      ham.lesser0,
-      ham.minor2,
-      ham.minor1,
-      ham.minor0
-    }
-  end
-
-  if isCata then
-    return {
-      ham.fel2,
-      ham.fel1,
-      ham.fel0,
-      ham.demonicWotLK2,
-      ham.demonicWotLK1,
-      ham.demonicWotLK0,
-      ham.master2,
-      ham.master1,
-      ham.master0,
-      ham.major2,
-      ham.major1,
-      ham.major0,
-      ham.greater2,
-      ham.greater1,
-      ham.greater0,
-      ham.healtsthone2,
-      ham.healtsthone1,
-      ham.healtsthone0,
-      ham.lesser2,
-      ham.lesser1,
-      ham.lesser0,
-      ham.minor2,
-      ham.minor1,
-      ham.minor0
-    }
-  end
-
-  if isMop then
-    return {
-      ham.healthstone,
-      --probably remove the stuff below since there should only be one healtsthone left with MoP
-      ham.fel2,
-      ham.fel1,
-      ham.fel0,
-      ham.demonicWotLK2,
-      ham.demonicWotLK1,
-      ham.demonicWotLK0,
-      ham.master2,
-      ham.master1,
-      ham.master0,
-      ham.major2,
-      ham.major1,
-      ham.major0,
-      ham.greater2,
-      ham.greater1,
-      ham.greater0,
-      ham.healtsthone2,
-      ham.healtsthone1,
-      ham.healtsthone0,
-      ham.lesser2,
-      ham.lesser1,
-      ham.lesser0,
-      ham.minor2,
-      ham.minor1,
-      ham.minor0
-    }
-  end
+  local key = getEnvKey()
+  return HEALTHSTONES_BY_ENV[key] or {}
 end

--- a/Core/Spells.lua
+++ b/Core/Spells.lua
@@ -1,5 +1,5 @@
 local addonName, ham = ...
-local isRetail = (WOW_PROJECT_ID == WOW_PROJECT_MAINLINE)
+local env = ham.env
 
 
 ham.crimsonVialSpell = 185311
@@ -28,29 +28,30 @@ ham.giftOfTheNaaruWarrior = 28880
 
 ham.bagOfTricks = 312411
 
-ham.supportedSpells = {}
-table.insert(ham.supportedSpells, ham.crimsonVialSpell)
-table.insert(ham.supportedSpells, ham.renewal)
-table.insert(ham.supportedSpells, ham.exhilaration)
-table.insert(ham.supportedSpells, ham.fortitudeOfTheBear)
-table.insert(ham.supportedSpells, ham.lastStand)
-table.insert(ham.supportedSpells, ham.bitterImmunity)
-table.insert(ham.supportedSpells, ham.desperatePrayer)
-table.insert(ham.supportedSpells, ham.expelHarm)
-table.insert(ham.supportedSpells, ham.healingElixir)
-table.insert(ham.supportedSpells, ham.darkPact)
-table.insert(ham.supportedSpells, ham.vampiricBlood)
-table.insert(ham.supportedSpells, ham.giftOfTheNaaruDK)
-table.insert(ham.supportedSpells, ham.giftOfTheNaaruHunter)
-table.insert(ham.supportedSpells, ham.giftOfTheNaaruMage)
-table.insert(ham.supportedSpells, ham.giftOfTheNaaruMageWarlock)
-table.insert(ham.supportedSpells, ham.giftOfTheNaaruMonk)
-table.insert(ham.supportedSpells, ham.giftOfTheNaaruPaladin)
-table.insert(ham.supportedSpells, ham.giftOfTheNaaruPriest)
-table.insert(ham.supportedSpells, ham.giftOfTheNaaruRogue)
-table.insert(ham.supportedSpells, ham.giftOfTheNaaruShaman)
-table.insert(ham.supportedSpells, ham.giftOfTheNaaruWarrior)
-table.insert(ham.supportedSpells, ham.bagOfTricks)
+ham.supportedSpells = {
+  ham.crimsonVialSpell,
+  ham.renewal,
+  ham.exhilaration,
+  ham.fortitudeOfTheBear,
+  ham.lastStand,
+  ham.bitterImmunity,
+  ham.desperatePrayer,
+  ham.expelHarm,
+  ham.healingElixir,
+  ham.darkPact,
+  ham.vampiricBlood,
+  ham.giftOfTheNaaruDK,
+  ham.giftOfTheNaaruHunter,
+  ham.giftOfTheNaaruMage,
+  ham.giftOfTheNaaruMageWarlock,
+  ham.giftOfTheNaaruMonk,
+  ham.giftOfTheNaaruPaladin,
+  ham.giftOfTheNaaruPriest,
+  ham.giftOfTheNaaruRogue,
+  ham.giftOfTheNaaruShaman,
+  ham.giftOfTheNaaruWarrior,
+  ham.bagOfTricks,
+}
 
 
 ham.Spell = {}
@@ -60,7 +61,7 @@ ham.Spell.new = function(id, name)
 
     self.id = id
     self.name = name
-    if isRetail == true then
+    if env and env.isRetail == true then
         self.cd = C_Spell.GetSpellCooldown(id).duration
     else
         self.cd = GetSpellBaseCooldown(id)
@@ -80,4 +81,31 @@ ham.Spell.new = function(id, name)
     end
 
     return self
+end
+
+-- Return localized spell name for both retail and classic clients
+function ham.getSpellName(spellId)
+  if env and env.isRetail == true then
+    return C_Spell.GetSpellName(spellId)
+  else
+    local name = GetSpellInfo(spellId)
+    return name
+  end
+end
+
+-- Return base cooldown in seconds (0 if none)
+function ham.getSpellBaseCooldownSeconds(spellId)
+  local ms = GetSpellBaseCooldown(spellId)
+  if not ms or ms <= 0 then return 0 end
+  return ms / 1000
+end
+
+-- Return spell icon texture id/path unified across clients
+function ham.getSpellTexture(spellId)
+  if env and env.isRetail == true then
+    local iconTexture = C_Spell.GetSpellTexture(spellId)
+    return iconTexture
+  else
+    return GetSpellTexture(spellId)
+  end
 end

--- a/FrameXML/InterfaceOptionsFrame.lua
+++ b/FrameXML/InterfaceOptionsFrame.lua
@@ -1,10 +1,7 @@
 ---@diagnostic disable: undefined-global
 local L = LibStub("AceLocale-3.0"):GetLocale("AutoPotion")
 local addonName, ham = ...
-local isRetail = (WOW_PROJECT_ID == WOW_PROJECT_MAINLINE)
-local isClassic = (WOW_PROJECT_ID == WOW_PROJECT_CLASSIC)
-local isWrath = (WOW_PROJECT_ID == WOW_PROJECT_WRATH_CLASSIC)
-local isCata = (WOW_PROJECT_ID == WOW_PROJECT_CATACLYSM_CLASSIC)
+local env = ham.env
 
 ---@class Frame
 ham.settingsFrame = CreateFrame("Frame")
@@ -29,6 +26,9 @@ local bandageFirstIcon = nil
 local bandagePositionX = 0
 local bandagePrioTitle = nil
 
+-- Keep references to generated option checkboxes
+local optionButtons = {}
+
 function ham.settingsFrame:updateConfig(option, value)
 	if ham.options[option] ~= nil then
 		ham.options[option] = value -- Update in-memory
@@ -45,17 +45,19 @@ function ham.settingsFrame:updateConfig(option, value)
 end
 
 function ham.settingsFrame:OnEvent(event, addOnName)
-	if addOnName == "AutoPotion" then
-		if event == "ADDON_LOADED" then
+    if addOnName == "AutoPotion" then
+        if event == ham.EVT_ADDON_LOADED then
 			HAMDB = HAMDB or CopyTable(ham.defaults)
+            ham.refreshOptions()
 			if HAMDB.activatedSpells == nil then
 				print(L["The Settings of AutoPotion were reset due to breaking changes."])
 				HAMDB = CopyTable(ham.defaults)
+                ham.refreshOptions()
 			end
 			self:InitializeOptions()
 		end
 	end
-	if event == "PLAYER_LOGIN" then
+    if event == ham.EVT_PLAYER_LOGIN then
 		self:InitializeClassSpells(myClassTitle)
 		ham.updateHeals()
 		ham.updateMacro()
@@ -64,29 +66,23 @@ function ham.settingsFrame:OnEvent(event, addOnName)
 	end
 end
 
-ham.settingsFrame:RegisterEvent("PLAYER_LOGIN")
-ham.settingsFrame:RegisterEvent("ADDON_LOADED")
+ham.settingsFrame:RegisterEvent(ham.EVT_PLAYER_LOGIN)
+ham.settingsFrame:RegisterEvent(ham.EVT_ADDON_LOADED)
 ham.settingsFrame:SetScript("OnEvent", ham.settingsFrame.OnEvent)
 
 function ham.settingsFrame:createPrioFrame(id, iconTexture, positionx, isSpell, isTinker)
-	local icon = CreateFrame("Frame", nil, self.content, UIParent)
+    if not self or not self.content or not currentPrioTitle then return nil end
+    local icon = CreateFrame("Frame", nil, self.content)
 	icon:SetFrameStrata("MEDIUM")
 	icon:SetWidth(ICON_SIZE)
 	icon:SetHeight(ICON_SIZE)
-	icon:HookScript("OnEnter", function(_, btn, down)
-		GameTooltip:SetOwner(icon, "ANCHOR_TOPRIGHT")
-		if isSpell == true then
-			GameTooltip:SetSpellByID(id)
-		elseif isTinker then
-			GameTooltip:SetInventoryItem("player", id)
-		else
-			GameTooltip:SetItemByID(id)
-		end
-		GameTooltip:Show()
-	end)
-	icon:HookScript("OnLeave", function(_, btn, down)
-		GameTooltip:Hide()
-	end)
+    if isSpell == true then
+        ham.ui.attachSpellTooltip(icon, id)
+    elseif isTinker then
+        ham.ui.attachInventoryTooltip(icon, id)
+    else
+        ham.ui.attachItemTooltip(icon, id)
+    end
 	local texture = icon:CreateTexture(nil, "BACKGROUND")
 	texture:SetTexture(iconTexture)
 	texture:SetAllPoints(icon)
@@ -99,7 +95,7 @@ function ham.settingsFrame:createPrioFrame(id, iconTexture, positionx, isSpell, 
 	else
 		icon:SetPoint("TOPLEFT", firstIcon, positionx, 0)
 	end
-	icon:Show()
+    icon:Show()
 	table.insert(prioFrames, icon)
 	table.insert(prioTextures, texture)
 	prioFramesCounter = prioFramesCounter + 1
@@ -108,18 +104,12 @@ end
 
 -- Create a bandage priority icon frame
 function ham.settingsFrame:createBandagePrioFrame(id, iconTexture, positionx)
-	local icon = CreateFrame("Frame", nil, self.content, UIParent)
+    if not self or not self.content or not bandagePrioTitle then return nil end
+    local icon = CreateFrame("Frame", nil, self.content)
 	icon:SetFrameStrata("MEDIUM")
 	icon:SetWidth(ICON_SIZE)
 	icon:SetHeight(ICON_SIZE)
-	icon:HookScript("OnEnter", function(_, btn, down)
-		GameTooltip:SetOwner(icon, "ANCHOR_TOPRIGHT")
-		GameTooltip:SetItemByID(id)
-		GameTooltip:Show()
-	end)
-	icon:HookScript("OnLeave", function(_, btn, down)
-		GameTooltip:Hide()
-	end)
+    ham.ui.attachItemTooltip(icon, id)
 	local texture = icon:CreateTexture(nil, "BACKGROUND")
 	texture:SetTexture(iconTexture)
 	texture:SetAllPoints(icon)
@@ -132,13 +122,14 @@ function ham.settingsFrame:createBandagePrioFrame(id, iconTexture, positionx)
 	else
 		icon:SetPoint("TOPLEFT", bandageFirstIcon, positionx, 0)
 	end
-	icon:Show()
+    icon:Show()
 	table.insert(bandageFrames, icon)
 	table.insert(bandageTextures, texture)
 	return icon
 end
 
 function ham.settingsFrame:updatePrio()
+    if not self or not self.content or not currentPrioTitle then return end
 	local spellCounter = 0
 	local itemCounter = 0
 
@@ -149,25 +140,13 @@ function ham.settingsFrame:updatePrio()
 	-- Add spells to priority frames
 	if next(ham.spellIDs) ~= nil then
 		for i, id in ipairs(ham.spellIDs) do
-			local iconTexture, originalIconTexture
-			if isRetail == true then
-				iconTexture, originalIconTexture = C_Spell.GetSpellTexture(id)
-			else
-				iconTexture = GetSpellTexture(id)
-			end
+            local iconTexture = ham.getSpellTexture and ham.getSpellTexture(id) or GetSpellTexture(id)
 			local currentFrame = prioFrames[i]
 			local currentTexture = prioTextures[i]
 			if currentFrame ~= nil then
-				currentFrame:SetScript("OnEnter", nil)
-				currentFrame:SetScript("OnLeave", nil)
-				currentFrame:HookScript("OnEnter", function(_, btn, down)
-					GameTooltip:SetOwner(currentFrame, "ANCHOR_TOPRIGHT")
-					GameTooltip:SetSpellByID(id)
-					GameTooltip:Show()
-				end)
-				currentFrame:HookScript("OnLeave", function(_, btn, down)
-					GameTooltip:Hide()
-				end)
+                currentFrame:SetScript("OnEnter", nil)
+                currentFrame:SetScript("OnLeave", nil)
+                ham.ui.attachSpellTooltip(currentFrame, id)
 				currentTexture:SetTexture(iconTexture)
 				currentTexture:SetAllPoints(currentFrame)
 				currentFrame.texture = currentTexture
@@ -188,36 +167,28 @@ function ham.settingsFrame:updatePrio()
 			local isTinker = false
 
 			-- if the entry is a gear slot (ie: tinker)
-			if type(id) == "string" and id:match("^slot:") then
-				local slot = assert(tonumber(id:sub(6)), "Invalid slot number")
+            if type(id) == "string" and id:match("^" .. ham.SLOT_PREFIX) then
+                local slot = assert(tonumber(id:sub(#ham.SLOT_PREFIX + 1)), "Invalid slot number")
 				entry = GetInventoryItemID("player", slot)
 				iconTexture = GetInventoryItemTexture("player", slot)
 				isTinker = true
 				-- otherwise its a normal item id
-			else
-				local _, _, _, _, _, _, _, _, _, tmpTexture = C_Item.GetItemInfo(id)
-				entry = id
-				iconTexture = tmpTexture
+            else
+                entry = id
+                iconTexture = ham.getItemIcon and ham.getItemIcon(id)
 			end
 
 			local currentFrame = prioFrames[i + spellCounter]
 			local currentTexture = prioTextures[i + spellCounter]
 
 			if currentFrame ~= nil then
-				currentFrame:SetScript("OnEnter", nil)
-				currentFrame:SetScript("OnLeave", nil)
-				currentFrame:HookScript("OnEnter", function(_, btn, down)
-					GameTooltip:SetOwner(currentFrame, "ANCHOR_TOPRIGHT")
-					if isTinker then
-						GameTooltip:SetInventoryItem("player", ham.tinkerSlot)
-					else
-						GameTooltip:SetItemByID(id)
-					end
-					GameTooltip:Show()
-				end)
-				currentFrame:HookScript("OnLeave", function(_, btn, down)
-					GameTooltip:Hide()
-				end)
+                currentFrame:SetScript("OnEnter", nil)
+                currentFrame:SetScript("OnLeave", nil)
+                if isTinker then
+                    ham.ui.attachInventoryTooltip(currentFrame, ham.tinkerSlot)
+                else
+                    ham.ui.attachItemTooltip(currentFrame, id)
+                end
 				currentTexture:SetTexture(iconTexture)
 				currentTexture:SetAllPoints(currentFrame)
 				currentFrame.texture = currentTexture
@@ -233,6 +204,7 @@ end
 
 -- Update the Bandage Priority section
 function ham.settingsFrame:updateBandagePrio()
+    if not self or not self.content or not bandagePrioTitle then return end
 	-- hide existing
 	for _, frame in pairs(bandageFrames) do
 		frame:Hide()
@@ -246,22 +218,15 @@ function ham.settingsFrame:updateBandagePrio()
 		local shown = 0
 		for _, item in ipairs(bandages) do
 			if item.getCount and item.getCount() > 0 then
-				local id = item.getId()
-				local _, _, _, _, _, _, _, _, _, iconTexture = C_Item.GetItemInfo(id)
+                local id = item.getId()
+                local iconTexture = ham.getItemIcon and ham.getItemIcon(id)
 				local idx = shown + 1
 				local currentFrame = bandageFrames[idx]
 				local currentTexture = bandageTextures[idx]
 				if currentFrame ~= nil then
-					currentFrame:SetScript("OnEnter", nil)
-					currentFrame:SetScript("OnLeave", nil)
-					currentFrame:HookScript("OnEnter", function(_, btn, down)
-						GameTooltip:SetOwner(currentFrame, "ANCHOR_TOPRIGHT")
-						GameTooltip:SetItemByID(id)
-						GameTooltip:Show()
-					end)
-					currentFrame:HookScript("OnLeave", function(_, btn, down)
-						GameTooltip:Hide()
-					end)
+                currentFrame:SetScript("OnEnter", nil)
+                currentFrame:SetScript("OnLeave", nil)
+                ham.ui.attachItemTooltip(currentFrame, id)
 					currentTexture:SetTexture(iconTexture)
 					currentTexture:SetAllPoints(currentFrame)
 					currentFrame.texture = currentTexture
@@ -310,57 +275,52 @@ function ham.settingsFrame:InitializeOptions()
 	behaviourTitle:SetPoint("TOPLEFT", subtitle, "BOTTOMLEFT", 0, -PADDING)
 	behaviourTitle:SetText(L["Addon Behaviour"])
 
-	-------------  Stop Casting  -------------	
-	local stopCastButton = CreateFrame("CheckButton", nil, self.content, "InterfaceOptionsCheckButtonTemplate")
-	stopCastButton:SetPoint("TOPLEFT", behaviourTitle, 0, -PADDING)
-	---@diagnostic disable-next-line: undefined-field
-	stopCastButton.Text:SetText(L["Include /stopcasting in the macro"])
-	stopCastButton:HookScript("OnClick", function(_, btn, down)
-		ham.settingsFrame:updateConfig("stopCast", stopCastButton:GetChecked())
-	end)
-	stopCastButton:HookScript("OnEnter", function(_, btn, down)
-		---@diagnostic disable-next-line: param-type-mismatch
-		GameTooltip:SetOwner(stopCastButton, "ANCHOR_TOPRIGHT")
-		GameTooltip:SetText(L["Useful for casters."])
-		GameTooltip:Show()
-	end)
-	stopCastButton:HookScript("OnLeave", function(_, btn, down)
-		GameTooltip:Hide()
-	end)
-	stopCastButton:SetChecked(HAMDB.stopCast)
-	lastStaticElement = stopCastButton
+    -- Helper to create a checkbox based on a schema spec
+    local function createOption(spec, anchorTo)
+        local btn = CreateFrame("CheckButton", nil, self.content, "InterfaceOptionsCheckButtonTemplate")
+        -- Position: either relative to given anchor or using grid (row/col) under the provided anchor
+        if spec.anchor == "grid" and anchorTo then
+            local x = (spec.col or 0) * PADDING_HORIZONTAL
+            local y = - (spec.row or 1) * PADDING
+            btn:SetPoint("TOPLEFT", anchorTo, x, y)
+        else
+            btn:SetPoint("TOPLEFT", anchorTo or behaviourTitle, spec.offsetX or 0, - (spec.offsetY or PADDING))
+        end
+        ---@diagnostic disable-next-line: undefined-field
+        btn.Text:SetText(spec.label)
+        btn:HookScript("OnClick", function()
+            ham.settingsFrame:updateConfig(spec.key, btn:GetChecked())
+        end)
+        if spec.onEnter then
+            btn:HookScript("OnEnter", function() spec.onEnter(btn) end)
+            btn:HookScript("OnLeave", function() GameTooltip:Hide() end)
+        elseif spec.tooltip then
+            btn:HookScript("OnEnter", function()
+                GameTooltip:SetOwner(btn, "ANCHOR_TOPRIGHT")
+                GameTooltip:SetText(spec.tooltip)
+                GameTooltip:Show()
+            end)
+            btn:HookScript("OnLeave", function() GameTooltip:Hide() end)
+        end
+        btn:SetChecked(ham.options[spec.key])
+        optionButtons[spec.key] = btn
+        return btn
+    end
 
-	-------------  Shortest Cooldown  -------------	
-	local cdResetButton = CreateFrame("CheckButton", nil, self.content, "InterfaceOptionsCheckButtonTemplate")
-	cdResetButton:SetPoint("TOPLEFT", lastStaticElement, 0, -PADDING)
-	---@diagnostic disable-next-line: undefined-field
-	cdResetButton.Text:SetText(L
-		["Includes the shortest Cooldown in the reset Condition of Castsequence. !!USE CAREFULLY!!"])
-	cdResetButton:HookScript("OnClick", function(_, btn, down)
-		ham.settingsFrame:updateConfig("cdReset", cdResetButton:GetChecked())
-	end)
-	cdResetButton:SetChecked(HAMDB.cdReset)
-	lastStaticElement = cdResetButton
+    -- Behavior options
+    local behaviorSchema = {
+        { key = "stopCast", label = L["Include /stopcasting in the macro"], tooltip = L["Useful for casters."], offsetX = 0, offsetY = PADDING },
+        { key = "cdReset", label = L["Includes the shortest Cooldown in the reset Condition of Castsequence. !!USE CAREFULLY!!"], offsetX = 0, offsetY = PADDING },
+        { key = "raidStone", label = L["Low Priority Healthstones"], onEnter = function(btn)
+            GameTooltip:SetOwner(btn, "ANCHOR_TOPRIGHT"); GameTooltip:SetText(L["Prioritize health potions over a healthstone."]); GameTooltip:Show()
+        end, offsetX = 0, offsetY = PADDING },
+    }
 
-	-------------  Healthstone Priority  -------------	
-	local raidStoneButton = CreateFrame("CheckButton", nil, self.content, "InterfaceOptionsCheckButtonTemplate")
-	raidStoneButton:SetPoint("TOPLEFT", lastStaticElement, 0, -PADDING)
-	---@diagnostic disable-next-line: undefined-field
-	raidStoneButton.Text:SetText(L["Low Priority Healthstones"])
-	raidStoneButton:HookScript("OnClick", function(_, btn, down)
-		ham.settingsFrame:updateConfig("raidStone", raidStoneButton:GetChecked())
-	end)
-	raidStoneButton:HookScript("OnEnter", function(_, btn, down)
-		---@diagnostic disable-next-line: param-type-mismatch
-		GameTooltip:SetOwner(raidStoneButton, "ANCHOR_TOPRIGHT")
-		GameTooltip:SetText(L["Prioritize health potions over a healthstone."])
-		GameTooltip:Show()
-	end)
-	raidStoneButton:HookScript("OnLeave", function(_, btn, down)
-		GameTooltip:Hide()
-	end)
-	raidStoneButton:SetChecked(HAMDB.raidStone)
-	lastStaticElement = raidStoneButton
+    local last = behaviourTitle
+    for _, spec in ipairs(behaviorSchema) do
+        last = createOption(spec, last)
+    end
+    lastStaticElement = last
 
 
 	-------------  ITEMS  -------------
@@ -368,92 +328,32 @@ function ham.settingsFrame:InitializeOptions()
 	local witheringDreamsPotionButton = nil
 	local cavedwellerDelightButton = nil
 	local heartseekingButton = nil
-	if isRetail then
-		local itemsTitle = self.content:CreateFontString("ARTWORK", nil, "GameFontNormalHuge")
-		itemsTitle:SetPoint("TOPLEFT", lastStaticElement, 0, -PADDING_CATERGORY)
-		itemsTitle:SetText(L["Items"])
+            if env and env.isRetail then
+        local itemsTitle = self.content:CreateFontString("ARTWORK", nil, "GameFontNormalHuge")
+        itemsTitle:SetPoint("TOPLEFT", lastStaticElement, 0, -PADDING_CATERGORY)
+        itemsTitle:SetText(L["Items"])
 
-		---Withering Potion---
-		witheringPotionButton = CreateFrame("CheckButton", nil, self.content, "InterfaceOptionsCheckButtonTemplate")
-		witheringPotionButton:SetPoint("TOPLEFT", itemsTitle, 0, -PADDING)
-		---@diagnostic disable-next-line: undefined-field
-		witheringPotionButton.Text:SetText(L["Potion of Withering Vitality"])
-		witheringPotionButton:HookScript("OnClick", function(_, btn, down)
-			ham.settingsFrame:updateConfig("witheringPotion", witheringPotionButton:GetChecked())
-		end)
-		witheringPotionButton:HookScript("OnEnter", function(_, btn, down)
-			---@diagnostic disable-next-line: param-type-mismatch
-			GameTooltip:SetOwner(witheringPotionButton, "ANCHOR_TOPRIGHT")
-			GameTooltip:SetItemByID(ham.witheringR3.getId())
-			GameTooltip:Show()
-		end)
-		witheringPotionButton:HookScript("OnLeave", function(_, btn, down)
-			GameTooltip:Hide()
-		end)
-		witheringPotionButton:SetChecked(HAMDB.witheringPotion)
+        local itemSchema = {
+            { key = "witheringPotion", label = L["Potion of Withering Vitality"], anchor = "grid", row = 1, col = 0, onEnter = function(btn)
+                GameTooltip:SetOwner(btn, "ANCHOR_TOPRIGHT"); GameTooltip:SetItemByID(ham.witheringR3.getId()); GameTooltip:Show()
+            end },
+            { key = "witheringDreamsPotion", label = L["Potion of Withering Dreams"], anchor = "grid", row = 1, col = 1, onEnter = function(btn)
+                GameTooltip:SetOwner(btn, "ANCHOR_TOPRIGHT"); GameTooltip:SetItemByID(ham.witheringDreamsR3.getId()); GameTooltip:Show()
+            end },
+            { key = "cavedwellerDelight", label = L["Cavedweller's Delight"], anchor = "grid", row = 1, col = 2, onEnter = function(btn)
+                GameTooltip:SetOwner(btn, "ANCHOR_TOPRIGHT"); GameTooltip:SetItemByID(ham.cavedwellersDelightR3.getId()); GameTooltip:Show()
+            end },
+            { key = "heartseekingInjector", label = L["Heartseeking Health Injector (tinker)"], anchor = "grid", row = 2, col = 0, onEnter = function(btn)
+                if ham.tinkerSlot then GameTooltip:SetOwner(btn, "ANCHOR_TOPRIGHT"); GameTooltip:SetInventoryItem("player", ham.tinkerSlot); GameTooltip:Show() end
+            end },
+        }
 
-		---Withering Dreams Potion---
-		witheringDreamsPotionButton = CreateFrame("CheckButton", nil, self.content, "InterfaceOptionsCheckButtonTemplate")
-		witheringDreamsPotionButton:SetPoint("TOPLEFT", itemsTitle, PADDING_HORIZONTAL, -PADDING)
-		---@diagnostic disable-next-line: undefined-field
-		witheringDreamsPotionButton.Text:SetText(L["Potion of Withering Dreams"])
-		witheringDreamsPotionButton:HookScript("OnClick", function(_, btn, down)
-			ham.settingsFrame:updateConfig("witheringDreamsPotion", witheringDreamsPotionButton:GetChecked())
-		end)
-		witheringDreamsPotionButton:HookScript("OnEnter", function(_, btn, down)
-			---@diagnostic disable-next-line: param-type-mismatch
-			GameTooltip:SetOwner(witheringDreamsPotionButton, "ANCHOR_TOPRIGHT")
-			GameTooltip:SetItemByID(ham.witheringDreamsR3.getId())
-			GameTooltip:Show()
-		end)
-		witheringDreamsPotionButton:HookScript("OnLeave", function(_, btn, down)
-			GameTooltip:Hide()
-		end)
-		witheringDreamsPotionButton:SetChecked(HAMDB.witheringDreamsPotion)
-
-		---Cavedwellers Delight---
-		cavedwellerDelightButton = CreateFrame("CheckButton", nil, self.content, "InterfaceOptionsCheckButtonTemplate")
-		cavedwellerDelightButton:SetPoint("TOPLEFT", itemsTitle, PADDING_HORIZONTAL * 2, -PADDING)
-		---@diagnostic disable-next-line: undefined-field
-		cavedwellerDelightButton.Text:SetText(L["Cavedweller's Delight"])
-		cavedwellerDelightButton:HookScript("OnClick", function(_, btn, down)
-			ham.settingsFrame:updateConfig("cavedwellerDelight", cavedwellerDelightButton:GetChecked())
-		end)
-		cavedwellerDelightButton:HookScript("OnEnter", function(_, btn, down)
-			---@diagnostic disable-next-line: param-type-mismatch
-			GameTooltip:SetOwner(cavedwellerDelightButton, "ANCHOR_TOPRIGHT")
-			GameTooltip:SetItemByID(ham.cavedwellersDelightR3.getId())
-			GameTooltip:Show()
-		end)
-		cavedwellerDelightButton:HookScript("OnLeave", function(_, btn, down)
-			GameTooltip:Hide()
-		end)
-		cavedwellerDelightButton:SetChecked(HAMDB.cavedwellerDelight)
-
-		---Heartseeking Health Injector---
-		heartseekingButton = CreateFrame("CheckButton", nil, self.content, "InterfaceOptionsCheckButtonTemplate")
-		--Padding*2 because its a new Row
-		heartseekingButton:SetPoint("TOPLEFT", itemsTitle, 0, -PADDING * 2)
-		---@diagnostic disable-next-line: undefined-field
-		heartseekingButton.Text:SetText(L["Heartseeking Health Injector (tinker)"])
-		heartseekingButton:HookScript("OnClick", function(_, btn, down)
-			ham.settingsFrame:updateConfig("heartseekingInjector", heartseekingButton:GetChecked())
-		end)
-		heartseekingButton:HookScript("OnEnter", function(_, btn, down)
-			---@diagnostic disable-next-line: param-type-mismatch
-			if ham.tinkerSlot then
-				GameTooltip:SetOwner(heartseekingButton, "ANCHOR_TOPRIGHT")
-				GameTooltip:SetInventoryItem("player", ham.tinkerSlot)
-				GameTooltip:Show()
-			end
-		end)
-		heartseekingButton:HookScript("OnLeave", function(_, btn, down)
-			GameTooltip:Hide()
-		end)
-		heartseekingButton:SetChecked(HAMDB.heartseekingInjector)
-
-		lastStaticElement = heartseekingButton
-	end
+        local lastItem
+        for _, spec in ipairs(itemSchema) do
+            lastItem = createOption(spec, itemsTitle)
+        end
+        lastStaticElement = lastItem or itemsTitle
+    end
 
 	-------------  CLASS / RACIALS  -------------
 	myClassTitle = self.content:CreateFontString("ARTWORK", nil, "GameFontNormalHuge")
@@ -486,16 +386,9 @@ function ham.settingsFrame:InitializeOptions()
 				button:SetChecked(false)
 			end
 		end
-		cdResetButton:SetChecked(HAMDB.cdReset)
-		raidStoneButton:SetChecked(HAMDB.raidStone)
-		if isRetail then
-			---@diagnostic disable-next-line: need-check-nil
-			witheringPotionButton:SetChecked(HAMDB.witheringPotion)
-			---@diagnostic disable-next-line: need-check-nil
-			witheringDreamsPotionButton:SetChecked(HAMDB.witheringDreamsPotion)
-			---@diagnostic disable-next-line: need-check-nil
-			cavedwellerDelightButton:SetChecked(HAMDB.cavedwellerDelight)
-		end
+        for key, btn in pairs(optionButtons) do
+            if btn and btn.SetChecked then btn:SetChecked(ham.options[key]) end
+        end
 		ham.updateHeals()
 		ham.updateMacro()
 		self:updatePrio()
@@ -511,7 +404,7 @@ function ham.settingsFrame:InitializeClassSpells(relativeTo)
 		local count = 0
 		for i, spell in ipairs(ham.supportedSpells) do
 			if IsSpellKnown(spell) or IsSpellKnown(spell, true) then
-				local name = C_Spell.GetSpellName(spell)
+				local name = ham.getSpellName(spell)
 				local button = CreateFrame("CheckButton", nil, self.content, "InterfaceOptionsCheckButtonTemplate")
 
 				if count == 3 then

--- a/code.lua
+++ b/code.lua
@@ -2,28 +2,30 @@ local L = LibStub("AceLocale-3.0"):GetLocale("AutoPotion")
 local addonName, ham = ...
 local macroName = L["AutoPotion"]
 local bandageMacroName = L["AutoBandage"] or "AutoBandage"
-local isRetail = (WOW_PROJECT_ID == WOW_PROJECT_MAINLINE)
-local isClassic = (WOW_PROJECT_ID == WOW_PROJECT_CLASSIC)
-local isWrath = (WOW_PROJECT_ID == WOW_PROJECT_WRATH_CLASSIC)
-local isCata = (WOW_PROJECT_ID == WOW_PROJECT_CATACLYSM_CLASSIC)
-local isMop = (WOW_PROJECT_ID == WOW_PROJECT_MISTS_CLASSIC)
+local env = ham.env
 
 -- Configuration options
 -- Use in-memory options as HAMDB updates are not persisted instantly.
 -- We'll also use lazy initialization to prevent early access issues.
+function ham.refreshOptions()
+  local src = HAMDB or ham.defaults or {}
+  ham.options = {
+    cdReset = not not src.cdReset,
+    stopCast = not not src.stopCast,
+    raidStone = not not src.raidStone,
+    witheringPotion = not not src.witheringPotion,
+    witheringDreamsPotion = not not src.witheringDreamsPotion,
+    -- default true only when nil, but respect explicit false in DB
+    cavedwellerDelight = (src.cavedwellerDelight == nil) and true or not not src.cavedwellerDelight,
+    heartseekingInjector = not not src.heartseekingInjector,
+  }
+end
+
 setmetatable(ham, {
   __index = function(t, k)
     if k == "options" then
-      t.options = {
-        cdReset = HAMDB.cdReset or false,
-        stopCast = HAMDB.stopCast or false,
-        raidStone = HAMDB.raidStone or false,
-        witheringPotion = HAMDB.witheringPotion or false,
-        witheringDreamsPotion = HAMDB.witheringDreamsPotion or false,
-        cavedwellerDelight = HAMDB.cavedwellerDelight or true,
-        heartseekingInjector = HAMDB.heartseekingInjector or false,
-      }
-      return t.options
+      ham.refreshOptions()
+      return ham.options
     end
   end
 })
@@ -41,23 +43,16 @@ local bagUpdates = false -- debounce watcher for BAG_UPDATE events
 local debounceTime = 3   -- seconds
 local combatRetry = 0    -- number of combat retries
 
--- MegaMacro addon compatibility
-local megaMacro = {
-  name = "MegaMacro", -- the addon name
-  retries = 0,        -- number of loaded checks to prevent infinite loop
-  checked = false,    -- did we check for the addon?
-  installed = false,  -- is the addon installed?
-  loaded = false,     -- is the addon loaded?
-}
+-- Macro application handled in Core/Macro.lua via ham.macro
 
 -- Slots to check for tinkers
 -- As of 2024-10-27, only Head, Wrist and Guns can have tinkers.
-local tinkerSlots = {
-  1,  -- Head
-  9,  -- Wrist
-  18, -- Gun
-  14, -- Trinket 2 (for debugging)
-}
+local function getTinkerSlots()
+  if ham.debug then
+    return { ham.SLOT_HEAD, ham.SLOT_WRIST, ham.SLOT_RANGED, ham.SLOT_TRINKET2 }
+  end
+  return { ham.SLOT_HEAD, ham.SLOT_WRIST, ham.SLOT_RANGED }
+end
 
 local function log(message)
   if ham.debug then
@@ -66,19 +61,13 @@ local function log(message)
 end
 
 local function addPlayerHealingItemIfAvailable()
-  if isRetail and ham.options.heartseekingInjector and ham.tinkerSlot then
-    table.insert(ham.itemIdList, "slot:" .. ham.tinkerSlot)
-  end
-  for i, value in ipairs(ham.myPlayer.getHealingItems()) do
-    if value.getCount() > 0 then
-      table.insert(ham.itemIdList, value.getId())
-      break;
-    end
+  if env and env.isRetail and ham.options.heartseekingInjector and ham.tinkerSlot then
+    table.insert(ham.itemIdList, ham.SLOT_PREFIX .. ham.tinkerSlot)
   end
 end
 
 local function addHealthstoneIfAvailable()
-  if isClassic == true or isWrath == true or isCata == true or isMop == true then
+  if env and (env.isClassic or env.isWrath or env.isCata or env.isMop) then
     for i, value in ipairs(ham.getHealthstonesClassic()) do
       if value.getCount() > 0 then
         table.insert(ham.itemIdList, value.getId())
@@ -119,6 +108,7 @@ local function addPotIfAvailable(useDelightPots)
 end
 
 function ham.updateHeals()
+  shortestCD = nil
   ham.itemIdList = {}
   ham.spellIDs = ham.myPlayer.getHealingSpells()
 
@@ -146,32 +136,11 @@ function ham.updateHeals()
   end
 end
 
-local function createMacroIfMissing()
-  -- dont create macro if MegaMacro is installed and loaded
-  if megaMacro.installed and megaMacro.loaded then
-    return
-  end
-  local name = GetMacroInfo(macroName)
-  if name == nil then
-    CreateMacro(macroName, "INV_Misc_QuestionMark")
-  end
-end
-
-local function createBandageMacroIfMissing()
-  -- dont create macro if MegaMacro is installed and loaded
-  if megaMacro.installed and megaMacro.loaded then
-    return
-  end
-  local name = GetMacroInfo(bandageMacroName)
-  if name == nil then
-    CreateMacro(bandageMacroName, "INV_Misc_QuestionMark")
-  end
-end
+-- creation handled by ham.macro when applying default macro path
 
 local function setShortestSpellCD(newSpell)
   if ham.options.cdReset then
-    local cd
-    cd = GetSpellBaseCooldown(newSpell) / 1000
+    local cd = ham.getSpellBaseCooldownSeconds(newSpell)
     if shortestCD == nil then
       shortestCD = cd
     end
@@ -191,111 +160,37 @@ end
 
 local function buildSpellMacroString()
   spellsMacroString = ''
-
   if next(ham.spellIDs) ~= nil then
-    for i, spell in ipairs(ham.spellIDs) do
-      local name
-      if isRetail == true then
-        name = C_Spell.GetSpellName(spell)
-      else
-        name = GetSpellInfo(spell)
-      end
-
+    local parts = {}
+    for _, spell in ipairs(ham.spellIDs) do
+      local name = ham.getSpellName(spell)
       setShortestSpellCD(spell)
-
-      --TODO HEALING Elixir Twice because it has two charges ?! kinda janky but will work for now
       if spell == ham.healingElixir then
-        name = name .. ", " .. name
-      end
-      if i == 1 then
-        spellsMacroString = name;
+        table.insert(parts, name)
+        table.insert(parts, name)
       else
-        spellsMacroString = spellsMacroString .. ", " .. name;
+        table.insert(parts, name)
       end
     end
+    spellsMacroString = table.concat(parts, ", ")
   end
 end
 
 local function buildItemMacroString()
+  itemsMacroString = ''
   if next(ham.itemIdList) ~= nil then
-    for i, name in ipairs(ham.itemIdList) do
-      local entry
-      -- Check if the entry starts with "slot:" and extract the slot number
-      if type(name) == "string" and name:match("^slot:") then
-        entry = name:sub(6)               -- Extract everything after "slot:"
-      else
-        entry = "item:" .. tostring(name) -- Default to item ID formatting
-      end
-      -- Add the entry to the macro string
-      if i == 1 then
-        itemsMacroString = entry
-      else
-        itemsMacroString = itemsMacroString .. ", " .. entry
-      end
+    local entries = {}
+    for _, name in ipairs(ham.itemIdList) do
+      table.insert(entries, ham.formatItemEntry(name))
     end
+    itemsMacroString = table.concat(entries, ", ")
   end
 end
 
-local function UpdateMegaMacro(newCode)
-  for _, macro in pairs(MegaMacroGlobalData.Macros) do
-    if macro.DisplayName == macroName then
-      MegaMacro.UpdateCode(macro, newCode)
-      log("MegaMacro updated with: " .. newCode)
-      return
-    end
-  end
-  print(
-    "|cffff0000AutoPotion Error:|r Missing global 'AutoPotion' macro in MegaMacro. Please create it then reload your game.")
-end
-
-local function UpdateMegaMacroByName(name, newCode)
-  for _, macro in pairs(MegaMacroGlobalData.Macros) do
-    if macro.DisplayName == name then
-      MegaMacro.UpdateCode(macro, newCode)
-      log("MegaMacro updated (" .. name .. ") with: " .. newCode)
-      return true
-    end
-  end
-  print("|cffff0000AutoPotion Error:|r Missing global '" ..
-    tostring(name) .. "' macro in MegaMacro. Please create it then reload your game.")
-  return false
-end
-
-local function checkMegaMacroAddon()
-  -- MegaMacro is only available for retail
-  if not isRetail then
-    megaMacro.checked = true
-    return
-  end
-
-  -- is MegaMacro installed?
-  local name = C_AddOns.GetAddOnInfo(megaMacro.name)
-  if not name then
-    megaMacro.installed = false
-    megaMacro.checked = true
-    return
-  end
-
-  megaMacro.installed = true
-
-  -- is the addon loaded?
-  if C_AddOns.IsAddOnLoaded(megaMacro.name) then
-    megaMacro.loaded = true
-    megaMacro.checked = true
-    return
-  end
-
-  -- Retry loading if not yet loaded
-  if megaMacro.retries < 3 then
-    megaMacro.retries = megaMacro.retries + 1
-    C_Timer.After(debounceTime, checkMegaMacroAddon)
-  else
-    megaMacro.checked = true
-  end
-end
+-- removed legacy MegaMacro helpers in favor of Core/Macro.lua
 
 -- Build bandage macro string (highest available bandage first)
-local function buildBandageMacroString()
+function ham.buildBandageMacro()
   local sequence = {}
   local bandages = ham.getBandages()
   for _, item in ipairs(bandages) do
@@ -313,9 +208,9 @@ end
 
 -- check if player has the engineering tinker: Heartseeking Health Injector
 function ham.checkTinker()
-  if not isRetail then return end
+  if not (env and env.isRetail) then return end
   ham.tinkerSlot = nil -- always reset
-  for _, slot in ipairs(tinkerSlots) do
+  for _, slot in ipairs(getTinkerSlots()) do
     local itemID = GetInventoryItemID("player", slot)
     if itemID then
       local spellName, spellID = C_Item.GetItemSpell(itemID)
@@ -338,7 +233,8 @@ function ham.checkTinker()
   end
 end
 
-function ham.updateMacro()
+function ham.buildMacro()
+  -- returns the macro string only
   if next(ham.itemIdList) == nil and next(ham.spellIDs) == nil then
     macroStr = "#showtooltip"
     if ham.options.stopCast then
@@ -364,59 +260,35 @@ function ham.updateMacro()
       macroStr = macroStr .. itemsMacroString
     end
   end
+  return macroStr
+end
 
-  if not megaMacro.checked then
-    log("MegaMacro not checked. Retrying.")
-    checkMegaMacroAddon()
-    return
-  end
+function ham.applyMacro(name, code)
+  local ok = ham.macro and ham.macro.apply and ham.macro.apply(name, code)
+  if ok then log('Macro updated.') end
+end
 
-  if megaMacro.installed and megaMacro.loaded then
-    UpdateMegaMacro(macroStr)
-    return
-  end
-
-  log('MegaMacro not in use. Creating default macro.')
-  createMacroIfMissing()
-
-  -- Use pcall to suppress LUA errors
-  local success, err = pcall(function()
-    EditMacro(macroName, macroName, nil, macroStr)
-  end)
-  if success then
-    log('Macro updated.')
-  end
+-- Backward-compatible wrappers used by UI
+function ham.updateMacro()
+  local code = ham.buildMacro()
+  ham.applyMacro(macroName, code)
 end
 
 function ham.updateBandageMacro()
-  local bandageMacroStr = buildBandageMacroString()
-  if megaMacro.installed and megaMacro.loaded then
-    UpdateMegaMacroByName(bandageMacroName, bandageMacroStr)
-  else
-    createBandageMacroIfMissing()
-    local success, err = pcall(function()
-      EditMacro(bandageMacroName, bandageMacroName, nil, bandageMacroStr)
-    end)
-    if success then
-      log('Bandage macro updated.')
-    end
-  end
+  local bandageCode = ham.buildBandageMacro()
+  ham.applyMacro(bandageMacroName, bandageCode)
 end
 
 local function MakeMacro()
-  -- dont attempt to create macro until MegaMacro addon is checked
-  if not megaMacro.checked then
-    log("MegaMacro not checked or loaded. Retrying.")
-    checkMegaMacroAddon()
-    return
-  end
+  -- ensure MegaMacro readiness check runs (non-blocking on non-retail)
+  if ham.macro and ham.macro.checkAddonReady then ham.macro.checkAddonReady() end
 
   -- retry if player is still in combat
   if InCombatLockdown() then
     if combatRetry < 4 then
       combatRetry = combatRetry + 1
       log("Player in combat. Retry attempt: " .. combatRetry)
-      C_Timer.After(0.5, MakeMacro)
+      ham.defer(0.5, MakeMacro)
     else
       log("Failed to update macro after 4 attempts.")
     end
@@ -441,26 +313,26 @@ local function onBagUpdate()
   end
   log("event: BAG_UPDATE")
   bagUpdates = true
-  C_Timer.After(debounceTime, function()
+  ham.defer(debounceTime, function()
     MakeMacro()
     bagUpdates = false
   end)
 end
 
 local updateFrame = CreateFrame("Frame")
-updateFrame:RegisterEvent("ADDON_LOADED")
-updateFrame:RegisterEvent("BAG_UPDATE")
-updateFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
-updateFrame:RegisterEvent("PLAYER_EQUIPMENT_CHANGED")
-if isClassic == false then
-  updateFrame:RegisterEvent("TRAIT_CONFIG_UPDATED")
+updateFrame:RegisterEvent(ham.EVT_ADDON_LOADED)
+updateFrame:RegisterEvent(ham.EVT_BAG_UPDATE)
+updateFrame:RegisterEvent(ham.EVT_PLAYER_ENTERING_WORLD)
+updateFrame:RegisterEvent(ham.EVT_PLAYER_EQUIPMENT_CHANGED)
+if env and not env.isClassic then
+  updateFrame:RegisterEvent(ham.EVT_TRAIT_CONFIG_UPDATED)
 end
-updateFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
-updateFrame:RegisterEvent("UNIT_PET")
+updateFrame:RegisterEvent(ham.EVT_PLAYER_REGEN_ENABLED)
+updateFrame:RegisterEvent(ham.EVT_UNIT_PET)
 updateFrame:SetScript("OnEvent", function(self, event, arg1, ...)
   -- when addon is loaded
-  if event == "ADDON_LOADED" and arg1 == addonName then
-    updateFrame:UnregisterEvent("ADDON_LOADED")
+  if event == ham.EVT_ADDON_LOADED and arg1 == addonName then
+    updateFrame:UnregisterEvent(ham.EVT_ADDON_LOADED)
     log("event: ADDON_LOADED")
     MakeMacro()
     return
@@ -470,28 +342,28 @@ updateFrame:SetScript("OnEvent", function(self, event, arg1, ...)
     return
   end
   -- bag update events
-  if event == "BAG_UPDATE" then
+  if event == ham.EVT_BAG_UPDATE then
     onBagUpdate()
     -- on loading/reloading
-  elseif event == "UNIT_PET" then
+  elseif event == ham.EVT_UNIT_PET then
     log("event: UNIT_PET")
     MakeMacro()
     -- when pet is called
-  elseif event == "PLAYER_ENTERING_WORLD" then
+  elseif event == ham.EVT_PLAYER_ENTERING_WORLD then
     log("event: PLAYER_ENTERING_WORLD")
     MakeMacro()
     -- on exiting combat
-  elseif event == "PLAYER_REGEN_ENABLED" then
+  elseif event == ham.EVT_PLAYER_REGEN_ENABLED then
     log("event: PLAYER_REGEN_ENABLED")
     -- Wait a second after combat ends to update the macro
     -- as the UI may still be cleaning up a protected state.
-    C_Timer.After(0.5, MakeMacro)
+    ham.defer(0.5, MakeMacro)
     -- when talents change and classic is false
-  elseif isClassic == false and event == "TRAIT_CONFIG_UPDATED" then
+  elseif env and not env.isClassic and event == ham.EVT_TRAIT_CONFIG_UPDATED then
     log("event: TRAIT_CONFIG_UPDATED")
     MakeMacro()
     -- when player changes equipment
-  elseif event == "PLAYER_EQUIPMENT_CHANGED" then
+  elseif event == ham.EVT_PLAYER_EQUIPMENT_CHANGED then
     log("event: PLAYER_EQUIPMENT_CHANGED")
     MakeMacro()
   end


### PR DESCRIPTION
…env/constants

- Init and DB safety
  - Hardened clean-install path: `getHealingSpells()` falls back to `ham.defaults.activatedSpells` when `HAMDB` is nil; options now refresh via `ham.refreshOptions()` on load/reset.
  - Normalized event/debounce usage with `ham.defer`.

- Macro architecture
  - Split build vs apply: `ham.buildMacro()`, `ham.buildBandageMacro()`, `ham.applyMacro(name, code)`.
  - Extracted MegaMacro integration into `Core/Macro.lua` (`checkAddonReady`, `apply`).
  - Macro item/spell string building uses helpers and `table.concat`.

- Env/constants
  - Centralized env checks via `ham.env`; added event constants (`ham.EVT_*`) and slot IDs.
  - Replaced magic strings/numbers in event registration and tinker slots.

- UI and UX
  - Fixed stray icons: frames are now children of settings content, guarded by panel init.
  - Added tooltip helpers; unified icon retrieval with `ham.getSpellTexture`/`ham.getItemIcon`.
  - Schema-driven options UI: generates behavior and item toggles from schema; reset updates all via registry.
  - `getSpellName` used for spell labels.

- Potions/Bandages data cleanup
  - Consolidated lists by environment (retail/classic/wrath/cata/mop) with `ham.getEnvKey()` and `ham.copyList()`; applied context filters (BG rules, options) centrally.

This reduces duplication, hardens startup, and keeps UI artifacts scoped to the settings panel.