### PR TITLE
TBC Injector

### DIFF
--- a/Core/Potions.lua
+++ b/Core/Potions.lua
@@ -231,6 +231,7 @@ function ham.getPots()
 
   if isTBC then
     local pots = {
+      ham.injector,
       ham.superreju,
       ham.auchenai,
       ham.super,


### PR DESCRIPTION
Fixed Healing Potion Injector from not being detected for TBC version